### PR TITLE
 Add null check before disposing of istr variable in finally block

### DIFF
--- a/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/GlyphList.cs
+++ b/src/iTextSharp.LGPLv2.Core/iTextSharp/text/pdf/GlyphList.cs
@@ -76,7 +76,10 @@ public static class GlyphList
         {
             try
             {
-                istr.Dispose();
+                if (istr != null)
+                {
+                    istr.Dispose();
+                }
             }
             catch
             {


### PR DESCRIPTION
During debugging, it was noticed that the `Stream` object (`istr`) is already disposed and set to null. However, the finally statement in the code does not check whether the object is null before calling the Dispose() method. 

This pull request addresses this issue by adding a null check before disposing of the `istr` variable in the finally block.  This ensures that the Dispose() method is only called if the object is not null, preventing any potential null reference exceptions.

**Fix**
```C#
 if (istr != null)
 {
      istr.Dispose();
 }
```       

#### Exception
```C#
System.NullReferenceException: Object reference not set to an instance of an object.
   at iTextSharp.text.pdf.GlyphList..cctor() in D:\a\iTextSharp.LGPLv2.Core\iTextSharp.LGPLv2.Core\src\iTextSharp.LGPLv2.Core\iTextSharp\text\pdf\GlyphList.cs:line 79
```
<img width="913" alt="glyph" src="https://github.com/deepumi/iTextSharp.LGPLv2.Core/assets/554039/7d3a8262-1df0-44ac-84ee-3981d676c810">
 

Additionally, the existing try-catch block is not required in this scenario since we are explicitly checking for null before disposing of the object. Removing the unnecessary try-catch block improves the code's readability and performance.
